### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Usage Example
     display = SSD1351(display_bus, width=128, height=128)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(128, 128, 1)

--- a/examples/ssd1351_128x96_simpletest.py
+++ b/examples/ssd1351_128x96_simpletest.py
@@ -26,7 +26,7 @@ display_bus = displayio.FourWire(
 display = SSD1351(display_bus, width=128, height=96)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(128, 96, 1)

--- a/examples/ssd1351_simpletest.py
+++ b/examples/ssd1351_simpletest.py
@@ -26,7 +26,7 @@ display_bus = displayio.FourWire(
 display = SSD1351(display_bus, width=128, height=128)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(128, 128, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a SSD1351 display to test with.